### PR TITLE
Add section links to Clojure README

### DIFF
--- a/contrib/clojure-package/README.md
+++ b/contrib/clojure-package/README.md
@@ -30,9 +30,9 @@ The following combinations of operating system and compute device are supported:
 
 There are three ways of getting started:
 
-1. Install [prebuilt Clojure jars](https://search.maven.org/search?q=clojure%20mxnet) with the native dependencies baked in. This the quickest way to get going.
-2. Install the Clojure package from source, but use prebuilt jars for the native dependencies. Choose this option if you want pre-release features of the Clojure package but don't want to build (compile) native dependencies yourself.
-3. Build everything from source. This option is for developers or advanced users who want cutting-edge features in all parts of the dependency chain.
+1. [Install prebuilt Clojure jars](#option-1-clojure-package-from-prebuilt-jar) with the native dependencies baked in. This the quickest way to get going.
+2. [Install the Clojure package from source, but use prebuilt jars for the native dependencies](#option-2-clojure-package-from-source-scala-package-from-jar). Choose this option if you want pre-release features of the Clojure package but don't want to build (compile) native dependencies yourself.
+3. [Build everything from source](#option-3-everything-from-source). This option is for developers or advanced users who want cutting-edge features in all parts of the dependency chain.
 
 **Note:** This guide assumes that you are familiar with the basics of creating Clojure projects and managing dependencies. See [here](https://github.com/technomancy/leiningen/blob/stable/doc/TUTORIAL.md) for the official Leiningen tutorial.
 


### PR DESCRIPTION
## Description ##
This is a README PR.

This PR links each Clojure install option in the Clojure README with the corresponding section containing instructions.

## Checklist ##
### Changes ###
- [x] Clojure README

## Comments ##
 - An existing link to Maven search is removed because it interferes with the section links and it is replicated in the Option 1 instructions below.
 - This is per my PR suggestion:
https://github.com/apache/incubator-mxnet/pull/12881/files/22bbe55d8d62be9ff3aebf693f73fa6049afc01d#r226822148
