### PR TITLE
Clojure BERT finetuning example: fix CSV parsing

### DIFF
--- a/contrib/clojure-package/examples/bert/fine-tune-bert.ipynb
+++ b/contrib/clojure-package/examples/bert/fine-tune-bert.ipynb
@@ -114,8 +114,6 @@
    ],
    "source": [
     "(def model-path-prefix \"data/static_bert_base_net\")\n",
-    ";; epoch number of the model\n",
-    "(def epoch 0)\n",
     ";; the vocabulary used in the model\n",
     "(def vocab (bert-util/get-vocab))\n",
     ";; the input question\n",
@@ -217,28 +215,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 9,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "He said the foodservice pie business doesn 't fit the company 's long-term growth strategy .\n",
-      " 100 percent behind George Bush \" and looked forward to using his years of training in the war .\n",
+      " The foodservice pie business does not fit our long-term growth strategy .\n",
       "1\n"
      ]
     }
    ],
    "source": [
-    "(def raw-file (csv/parse-csv (slurp \"data/dev.tsv\") :delimiter \\tab))\n",
+    "(def raw-file \n",
+    "    (csv/parse-csv (string/replace (slurp \"data/dev.tsv\") \"\\\"\" \"\")\n",
+    "                   :delimiter \\tab\n",
+    "                   :strict true))\n",
+    "\n",
     "(def data-train-raw (->> raw-file\n",
-    "                            (mapv #(vals (select-keys % [3 4 0])))\n",
-    "                            (rest) ;;drop header\n",
-    "                            (into [])\n",
-    "                            ))\n",
+    "                         (mapv #(vals (select-keys % [3 4 0])))\n",
+    "                         (rest) ; drop header\n",
+    "                         (into [])))\n",
+    "\n",
     "(def sample (first data-train-raw))\n",
     "(println (nth sample 0)) ;;;sentence a\n",
     "(println (nth sample 1)) ;; sentence b\n",


### PR DESCRIPTION
## Description ##
Fixes CSV parsing issues raised in [my PR comment](https://github.com/apache/incubator-mxnet/pull/14769#discussion_r280032563). Specifically, this PR modifies the Jupyter notebook to:

 - strip quotation marks from the parsed CSV file, preventing the accidental merging of separate examples
 - use strict CSV parsing to surface any similar problems in the future
 - remove an unused `epoch` def

I *think* this works OK for all examples. It's possible that not having quotation marks negatively affects correct performance, but if so, it would be less so than mixing up examples with each other.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
